### PR TITLE
fixes issue #4 by changing get to post protocol in reset

### DIFF
--- a/src/main/java/eu/rekawek/toxiproxy/HttpClient.java
+++ b/src/main/java/eu/rekawek/toxiproxy/HttpClient.java
@@ -67,6 +67,14 @@ public class HttpClient {
         return readResponse(connection, clazz);
     }
 
+    public int post(String path) throws IOException {
+        HttpURLConnection connection = getConnection(path);
+        connection.setDoOutput(true);
+        connection.setRequestMethod("POST");
+        connection.getInputStream().close();
+        return connection.getResponseCode();
+    }
+
     public JsonObject post(String path, JsonObject data) throws IOException {
         HttpURLConnection connection = getConnection(path);
         connection.setDoOutput(true);

--- a/src/main/java/eu/rekawek/toxiproxy/ToxiproxyClient.java
+++ b/src/main/java/eu/rekawek/toxiproxy/ToxiproxyClient.java
@@ -47,7 +47,7 @@ public class ToxiproxyClient {
     }
 
     public void reset() throws IOException {
-        httpClient.get("/reset");
+        httpClient.post("/reset");
     }
 
     public String version() throws IOException {


### PR DESCRIPTION
Basically reset requires a call to `POST /reset` but without any body content. For this reason I created a post method that does not send any content.