### PR TITLE
Fixes http error mapping - title field is now error

### DIFF
--- a/src/main/java/eu/rekawek/toxiproxy/HttpClient.java
+++ b/src/main/java/eu/rekawek/toxiproxy/HttpClient.java
@@ -1,8 +1,8 @@
 package eu.rekawek.toxiproxy;
 
-import static java.lang.String.format;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -10,12 +10,8 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.nio.Buffer;
-import java.nio.ByteOrder;
-import java.nio.CharBuffer;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
+import static java.lang.String.format;
 
 public class HttpClient {
 
@@ -106,7 +102,7 @@ public class HttpClient {
         final int status = connection.getResponseCode();
         if (status < 200 || status > 299) {
             JsonObject error = readAndClose(connection.getErrorStream(), JsonObject.class);
-            String errorMsg = format("[%d] %s", error.get("status").getAsLong(), error.get("title").getAsString());
+            String errorMsg = format("[%d] %s", error.get("status").getAsLong(), error.get("error").getAsString());
             throw new IOException(errorMsg);
         } else {
             return readAndClose(connection.getInputStream(), clazz);

--- a/src/test/java/eu/rekawek/toxiproxy/ToxiproxyClientTest.java
+++ b/src/test/java/eu/rekawek/toxiproxy/ToxiproxyClientTest.java
@@ -1,20 +1,25 @@
 package eu.rekawek.toxiproxy;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.util.List;
-
 import eu.rekawek.toxiproxy.model.ToxicDirection;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ToxiproxyClientTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     private final ToxiproxyClient tp = new ToxiproxyClient();
 
@@ -55,6 +60,7 @@ public class ToxiproxyClientTest {
         assertEquals("127.0.0.1:26379", proxy.getListen());
         assertEquals("localhost:6379", proxy.getUpstream());
     }
+
 
     @Test
     public void testListProxy() throws IOException {
@@ -105,5 +111,14 @@ public class ToxiproxyClientTest {
 
         assertTrue(proxy.toxics().getAll().isEmpty());
         assertTrue(proxy.isEnabled());
+    }
+
+    @Test
+    public void should_fail_with_error_code_and_message_when_trying_to_create_already_existing_proxy() throws Exception {
+        expectedException.expect(IOException.class);
+        expectedException.expectMessage("[409] proxy already exists");
+
+        Proxy proxy = tp.createProxy("test-proxy", "127.0.0.1:26379", "localhost:6379");
+        Proxy shouldThrowError = tp.createProxy("test-proxy", "127.0.0.1:26379", "localhost:6379");
     }
 }


### PR DESCRIPTION
Since version 2.1.0 of toxiproxy title is no longer part of returned JSON payload. From now on error message is in `error` field. Here's the [relevant commit](https://github.com/Shopify/toxiproxy/commit/2526adc590a5f1e80d37dce7e39a68045eee250c#diff-651a84f8ad6a38c1f7ccdf63f2692410L385).
 